### PR TITLE
Check parent resource permission

### DIFF
--- a/nextgisweb_qgis/model.py
+++ b/nextgisweb_qgis/model.py
@@ -132,6 +132,11 @@ class QgisVectorStyle(Base, Resource):
         return res_img
 
 
+DataScope.read.require(
+    DataScope.read,
+    attr='parent', cls=QgisVectorStyle)
+
+
 class RenderRequest(object):
     implements(IExtentRenderRequest, ITileRenderRequest)
 


### PR DESCRIPTION
Данное исправление аналогично [этому](https://github.com/nextgis/nextgisweb_mapserver/commit/fb95f25be91dc8ae9a57bb5c92fac786ca5b2122), только для QGIS рендерера. Однако, если его применить, то NGW не запускается с ошибкой:

```
Traceback (most recent call last):
  File "/home/rykov/git/ngw2/env/bin/pserve", line 11, in <module>
    sys.exit(main())
  File "/home/rykov/git/ngw2/env/local/lib/python2.7/site-packages/pyramid/scripts/pserve.py", line 58, in main
    return command.run()
  File "/home/rykov/git/ngw2/env/local/lib/python2.7/site-packages/pyramid/scripts/pserve.py", line 328, in run
    global_conf=vars)
  File "/home/rykov/git/ngw2/env/local/lib/python2.7/site-packages/pyramid/scripts/pserve.py", line 363, in loadapp
    return loadapp(app_spec, name=name, relative_to=relative_to, **kw)
  File "/home/rykov/git/ngw2/env/local/lib/python2.7/site-packages/paste/deploy/loadwsgi.py", line 247, in loadapp
    return loadobj(APP, uri, name=name, **kw)
  File "/home/rykov/git/ngw2/env/local/lib/python2.7/site-packages/paste/deploy/loadwsgi.py", line 272, in loadobj
    return context.create()
  File "/home/rykov/git/ngw2/env/local/lib/python2.7/site-packages/paste/deploy/loadwsgi.py", line 710, in create
    return self.object_type.invoke(self)
  File "/home/rykov/git/ngw2/env/local/lib/python2.7/site-packages/paste/deploy/loadwsgi.py", line 146, in invoke
    return fix_call(context.object, context.global_conf, **context.local_conf)
  File "/home/rykov/git/ngw2/env/local/lib/python2.7/site-packages/paste/deploy/util.py", line 55, in fix_call
    val = callable(*args, **kw)
  File "/home/rykov/git/ngw2/nextgisweb/nextgisweb/__init__.py", line 66, in main
    env = Env(cfg)
  File "/home/rykov/git/ngw2/nextgisweb/nextgisweb/env.py", line 21, in __init__
    components_ignore=components_ign)
  File "/home/rykov/git/ngw2/nextgisweb/nextgisweb/component.py", line 93, in load_all
    for pkg in pkginfo.packages:
  File "/home/rykov/git/ngw2/nextgisweb/nextgisweb/package.py", line 54, in packages
    self.scan()
  File "/home/rykov/git/ngw2/nextgisweb/nextgisweb/package.py", line 29, in scan
    pkginfo = epoint.load()()
  File "build/bdist.linux-x86_64/egg/pkg_resources/__init__.py", line 2355, in load
  File "build/bdist.linux-x86_64/egg/pkg_resources/__init__.py", line 2361, in resolve
  File "/home/rykov/git/ngw2/nextgisweb_qgis/nextgisweb_qgis/__init__.py", line 30, in <module>
    from .model import Base
  File "/home/rykov/git/ngw2/nextgisweb_qgis/nextgisweb_qgis/model.py", line 137, in <module>
    attr='parent', cls=QgisVectorStyle)
  File "/home/rykov/git/ngw2/nextgisweb/nextgisweb/resource/permission.py", line 95, in require
    tgt.toposort()
  File "/home/rykov/git/ngw2/nextgisweb/nextgisweb/resource/permission.py", line 35, in toposort
    assert not g, "A cyclic dependency exists amongst %r" % g
AssertionError: A cyclic dependency exists amongst {<Requirement: (<Permission 'read' in scope 'data'>) requires (<Permission 'read' in scope 'data'>) on attr=parent>: set([<Requirement: (<Permission 'read' in scope 'data'>) requires (<Permission 'read' in scope 'data'>) on attr=parent>]), <Requirement: (<Permission 'read' in scope 'data'>) requires (<Permission 'read' in scope 'data'>) on attr=parent>: set([<Requirement: (<Permission 'read' in scope 'data'>) requires (<Permission 'read' in scope 'data'>) on attr=parent>]), <Requirement: (<Permission 'write' in scope 'data'>) requires (<Permission 'read' in scope 'data'>) on attr=None>: set([<Requirement: (<Permission 'read' in scope 'data'>) requires (<Permission 'read' in scope 'data'>) on attr=parent>, <Requirement: (<Permission 'read' in scope 'data'>) requires (<Permission 'read' in scope 'data'>) on attr=parent>])}
```
